### PR TITLE
Убрать лишний билд из Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,36 +24,6 @@ help:
 # Dependencies
 # ================================================================================================
 
-# People say it takes 5 mins to 2 hours to build from sources
-# https://forum.opencv.org/t/can-i-use-opencv-python-with-gpu/8947/2
-build_opencv/opencv-python/dist:
-	mkdir build_opencv
-	cd build_opencv && git clone https://github.com/opencv/opencv && git clone https://github.com/opencv/opencv_contrib
-	cd build_opencv %% cmake -DOPENCV_EXTRA_MODULES_PATH=opencv_contrib/modules  \
-       -DBUILD_SHARED_LIBS=OFF \
-       -DBUILD_TESTS=OFF \
-       -DBUILD_PERF_TESTS=OFF \
-       -DBUILD_EXAMPLES=OFF \
-       -DWITH_OPENEXR=OFF \
-       -DWITH_CUDA=ON \
-       -DWITH_CUBLAS=ON \
-       -DWITH_CUDNN=ON \
-       -DOPENCV_DNN_CUDA=ON \
-       /opencv
-	make -j8 install
-	cd opencv-python && pip wheel . --verbose
-
-# https://stackoverflow.com/questions/27885397/how-do-i-install-a-python-package-with-a-whl-file
-.PHONY: install_opencv_cuda
-install_opencv_cuda: build_opencv/opencv-python/dist
-	@echo Installing built pip wheel...
-	$(python) -m pip install build_opencv/opencv-python/dist/*.whl
-
-.PHONY: clean_opencv
-clean_opencv:
-	rm build_opencv/*
-	rmdir build_opencv
-
 .PHONY: install
 install:
 	$(python) -m pip install -r requirements/prod.txt


### PR DESCRIPTION
В ходе разработки проекта было принято решение не использовать нейросети для дешумизации изображений на данный момент. По крайней мере, если это будет производиться, то точно не через сборку opencv из исходников, в связи с чем можем свобдно попрощаться с ним.